### PR TITLE
Auto-download results from harvard.edu

### DIFF
--- a/etl/extract-results.py
+++ b/etl/extract-results.py
@@ -1,13 +1,11 @@
 '''
-County-level past election results are manually downloaded from Harvard Dataverse:
-https://dataverse.harvard.edu/file.xhtml?fileId=6104822&version=10.0 
-
-This process could be automated via API. However, this is a static source,
-so a one-time download was sufficient.
-
 Citation:
 
 MIT Election Data and Science Lab, 2018, "County Presidential Election Returns 2000-2020", 
 https://doi.org/10.7910/DVN/VOQCHQ, Harvard Dataverse, V10; countypres_2000-2020.tab [fileName], 
 UNF:6:pVAMya52q7VM1Pl7EZMW0Q== [fileUNF] 
 '''
+
+from helpers.extract import extract
+
+extract('https://dataverse.harvard.edu/api/access/datafile/6104822', 'data/raw/results_county.csv')


### PR DESCRIPTION
I got curious about whether you could automate this, so had a look at the api

```py
from pyDataverse.api import NativeApi, DataAccessApi

BASE_URL = 'https://dataverse.harvard.edu'
DOI = 'doi:10.7910/DVN/VOQCHQ'

api = NativeApi(BASE_URL)
data_api = DataAccessApi(BASE_URL)

files_list = api.get_dataset(DOI).json()['data']['latestVersion']['files']

for file in files_list:
    filename = file["dataFile"]["filename"]
    file_id = file["dataFile"]["id"]
    print(f"File name {filename}, id {file_id}")

    response = data_api.get_datafile(file_id)
    with open(filename, "wb") as f:
        f.write(response.content)
```

is roughly what I used to find the url